### PR TITLE
Add Gemini API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ streamlit run app.py
 ```
 Once you have made changes to the code, save, move focus to the streamlit tab, then press c to clear caches if necessary, then r to rerun. 
 
-You also need to have access to GPT API to use this package. We hope to have a Llama compatible version soon. 
+You also need to have access to GPT API to use this package. Alternatively, you need access to Gemini API but that requires changes to the [.streamlit/secrets.toml](.streamlit/secrets.toml) file (see below).
 
 ## How does it work?
 ### App
@@ -80,3 +80,18 @@ The get_relevant_info(input) both retrieves the synthesize_text() from the descr
 ### Embeddings
 
 Certain files in /data/describe/ contain question-answer pairs that are embedded by pages/embedder.py. You can run this app by clicking on 'Embedding Tool' in top left corner of the app. This is then used to search (using cosine similarity) for the best question-answer pairs for answering the users query.
+
+
+### Using Gemini API
+If, instead of using OpenAI's API, you want to use Google's. You need to add the following lines to your [.streamlit/secrets.toml](.streamlit/secrets.toml) file.
+
+```toml
+USE_GEMINI = true
+GEMINI_API_KEY = "YOUR_API_KEY"
+
+# Can use any chat model
+GEMINI_CHAT_MODEL = "gemini-1.5-flash"
+
+# Can use any embedding model
+GEMINI_EMBEDDING_MODEL = "models/text-embedding-004"
+```

--- a/classes/embeddings.py
+++ b/classes/embeddings.py
@@ -4,7 +4,7 @@ import openai
 from utils.embeddings_utils import get_embedding, cosine_similarity
 import os
 
-from settings import ENGINE_ADA, GPT3_BASE, GPT3_VERSION, GPT3_KEY
+from settings import ENGINE_ADA, GPT3_BASE, GPT3_VERSION, GPT3_KEY, USE_GEMINI, GEMINI_EMBEDDING_MODEL, GEMINI_API_KEY
 
 class Embeddings:
     def __init__(self):
@@ -15,11 +15,17 @@ class Embeddings:
         # if type is not specified, it will search all dataframes
         # otherwise it will search those listed
 
-        openai.api_base = GPT3_BASE
-        openai.api_version = GPT3_VERSION
-        openai.api_key = GPT3_KEY
-        # text-embedding-ada-002 (Version 2) model
-        embedding = get_embedding(query, engine=ENGINE_ADA)
+        if USE_GEMINI:
+            import google.generativeai as genai
+            genai.configure(api_key=GEMINI_API_KEY)
+            ENGINE = GEMINI_EMBEDDING_MODEL
+        else:
+            openai.api_base = GPT3_BASE
+            openai.api_version = GPT3_VERSION
+            openai.api_key = GPT3_KEY
+            # text-embedding-ada-002 (Version 2) model
+            ENGINE = ENGINE_ADA
+        embedding = get_embedding(query, engine=ENGINE, use_gemini=USE_GEMINI)
 
         # An option for the future is to take the top from each dataframe, so we get a mixture of responses.
         df = self.df_dict
@@ -32,17 +38,24 @@ class Embeddings:
     def compare_strings(self,string1,string2):
         # Use this function to compare two strings or words embeddings
         # Returns co-sine similarilty between the two strings
-        embedding1 = get_embedding(string1, engine=ENGINE_ADA)
-        embedding2 = get_embedding(string2, engine=ENGINE_ADA)
+        ENGINE = GEMINI_EMBEDDING_MODEL if USE_GEMINI else ENGINE_ADA
+        embedding1 = get_embedding(string1, engine=ENGINE, use_gemini=USE_GEMINI)
+        embedding2 = get_embedding(string2, engine=ENGINE, use_gemini=USE_GEMINI)
 
         return cosine_similarity(embedding1, embedding2)
     
     def return_embedding(self,query):
-        openai.api_base = GPT3_BASE
-        openai.api_version = GPT3_VERSION
-        openai.api_key = GPT3_KEY
-        # text-embedding-ada-002 (Version 2) model
-        embedding = get_embedding(query, engine=ENGINE_ADA)
+        if USE_GEMINI:
+            import google.generativeai as genai
+            genai.configure(api_key=GEMINI_API_KEY)
+            ENGINE = GEMINI_EMBEDDING_MODEL
+        else:
+            openai.api_base = GPT3_BASE
+            openai.api_version = GPT3_VERSION
+            openai.api_key = GPT3_KEY
+            # text-embedding-ada-002 (Version 2) model
+            ENGINE = ENGINE_ADA
+        embedding = get_embedding(query, engine=ENGINE, use_gemini=USE_GEMINI)
         
         return embedding    
         

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ numpy==1.26.3
 matplotlib==3.7.2
 openai==0.28.1
 openai[embeddings]==0.28.1
+google-generativeai==0.7.2
 tiktoken
 python-jose==3.3.0
 customerio==2.1

--- a/settings.py
+++ b/settings.py
@@ -12,6 +12,11 @@ GPT4_VERSION = st.secrets.get('GPT4o_VERSION')
 GPT4_KEY = st.secrets.get('GPT4o_KEY')
 GPT4_ENGINE = st.secrets.get("GPT4o_ENGINE")
 
+# Gemini secrets
+USE_GEMINI = st.secrets.get("USE_GEMINI", False)
+GEMINI_API_KEY = st.secrets.get("GEMINI_API_KEY", "")
+GEMINI_CHAT_MODEL = st.secrets.get("GEMINI_CHAT_MODEL", "")
+GEMINI_EMBEDDING_MODEL = st.secrets.get("GEMINI_EMBEDDING_MODEL", "")
 
 if GPT_DEFAULT == "4":
     GPT_BASE = GPT4_BASE

--- a/utils/gemini.py
+++ b/utils/gemini.py
@@ -1,0 +1,25 @@
+"""
+Utilities for more easily convert OpenAI API calls to Gemini API calls.
+"""
+
+
+def convert_messages_format(messages):
+    new_messages = []
+    system_prompt = None
+    if len(messages) > 0 and messages[0]["role"] == "system":
+        # If the first message is a system message, store it and return it.
+        # Gemini requires the system prompt to be passed in separately.
+        system_prompt = messages[0]["content"]
+        messages = messages[1:]
+    for message in messages:
+        role = "model" if message["role"] == "assistant" else "user"
+        new_message = {
+            "role": role,
+            "parts": message["content"],
+        }
+        new_messages.append(new_message)
+
+    user_query = ""
+    if new_messages[-1]["role"] == "user":
+        user_query = new_messages.pop()
+    return {"system_instruction": system_prompt, "history": new_messages, "content": user_query}


### PR DESCRIPTION
## Summary
Integrate Gemini API as an alternative to OpenAI's.

## Changes Made
Added 4 secret constants to support Gemini, all have a default value so no changes are required to legacy code.
Changes to [chat.py](classes/chat.py), [description.py](classes/description.py) and [embeddings_utils.py](utils/embeddings_utils.py) to check whether to use Gemini or GPT and generate from the corresponding API. README has been extended with instructions on how to use Gemini.

## How Has This Been Tested?
- [x] It runs
- [ ] It does what it should*

*I tried running it but could not assess whether the behaviour is the one intended. More checks are needed in this regard. Similar concerns are also for the legacy part (which *should* not have changed).